### PR TITLE
draft: Valgrind splat fixes

### DIFF
--- a/lib/direct/os/linux/thread.c
+++ b/lib/direct/os/linux/thread.c
@@ -228,6 +228,7 @@ const char *
 direct_thread_self_name()
 {
      DirectThread *thread = direct_thread_self();
+     char name[16];
 
      /* This function is called by debugging functions, e.g. debug messages, assertions etc.
         Therefore no assertions are made here, because they would loop forever if they fail. */
@@ -236,7 +237,8 @@ direct_thread_self_name()
           return NULL;
 
      if (!thread->name) {
-          prctl( PR_GET_NAME, thread->name, 0, 0, 0 );
+          prctl( PR_GET_NAME, name, 0, 0, 0 );
+          thread->name = strdup(name);
      }
 
      return thread->name;


### PR DESCRIPTION
While adding directfb2 to my buildroot based system I've seen a few seqfaults when the application exits.
I've setup a QEMU vm with the same binaries + valgrind to find the memory errors causing the segfaults.

This PR contains fixes for a few of the issues found.