### PR TITLE
build: Fix issues with build order and directfb_strings

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -174,7 +174,7 @@ configure_file(configuration: build_h,
                install_dir: join_paths(get_option('includedir'), 'directfb-internal'))
 
 libdirectfb = library('directfb-@0@.@1@'.format(directfb_major_version, directfb_minor_version),
-                      directfb_sources, flux_sources, surface_pool_sources,
+                      directfb_sources, flux_sources, surface_pool_sources, directfb_strings,
                       include_directories: [config_inc, directfb_inc],
                       c_args: ['-DBUILDTIME="' + run_command('date', '-u', '+%Y-%m-%d %H:%M').stdout().strip() + '"',
                                '-DSYSCONFDIR="/dfb/etc"'],

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -21,5 +21,6 @@ executable('dfbg',
 
 executable('dfbinfo',
            'dfbinfo.c',
+           directfb_strings,
            dependencies: directfb_dep,
            install: true)


### PR DESCRIPTION
The header generated by directfb_strings is used in other places.
If the build is done in parallel and directfb_strings hasn't completed
yet the build will fail.

Add directfb_strings as an input to the places that need it so that
it always happens before it's needed.