### PR TITLE
WM/Default: Set the shape of the cursor bound to a window

### DIFF
--- a/wm/default/default.c
+++ b/wm/default/default.c
@@ -662,6 +662,9 @@ switch_focus( WMData          *wmdata,
                }
           }
 
+          if (to->cursor.surface)
+               dfb_windowstack_cursor_set_shape( stack, to->cursor.surface, to->cursor.hot_x, to->cursor.hot_y );
+
           we.type = DWET_GOTFOCUS;
 
           post_event( to, data, &we );


### PR DESCRIPTION
Set the shape of the cursor bound to a window each time the cursor enters it.