### PR TITLE
Alias __NR_futex with __NR_futex_time64 for RV32 platform

### DIFF
--- a/lib/direct/os/linux/system.c
+++ b/lib/direct/os/linux/system.c
@@ -25,6 +25,10 @@
 #include <direct/os/system.h>
 #include <direct/os/thread.h>
 
+#if !defined(__NR_futex) && defined(__NR_futex_time64)
+#define __NR_futex __NR_futex_time64
+#endif
+
 D_DEBUG_DOMAIN( Direct_Futex, "Direct/Futex", "Direct Futex" );
 D_DEBUG_DOMAIN( Direct_Trap,  "Direct/Trap",  "Direct Trap" );
 


### PR DESCRIPTION
Since version 5.1, `Linux` has dropped several `RISC-V 32-bit` syscalls by removing `__ARCH_WANT_TIME32_SYSCALLS` macro, causing the compilation of `DirectFB2` to fail on RV32 platform with error of no definition of __NR_futex is declared.

To resolve the issue, this pull request aliases `__NR_futex` with `__NR_futex_time64` as a fallback solution.

```
[19/181] Compiling C object lib/direct/libdirect-2.0.so.0.0.0.p/os_linux_system.c.o
FAILED: lib/direct/libdirect-2.0.so.0.0.0.p/os_linux_system.c.o 
riscv32-buildroot-linux-gnu-gcc -Ilib/direct/libdirect-2.0.so.0.0.0.p -Ilib/direct -I../../lib/direct -I. -I../.. -Ilib -I../../lib -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O3 -Wstrict-prototypes -fPIC -pthread '-DMODULEDIR="/usr/local/lib/directfb-2.0-0"' -MD -MQ lib/direct/libdirect-2.0.so.0.0.0.p/os_linux_system.c.o -MF lib/direct/libdirect-2.0.so.0.0.0.p/os_linux_system.c.o.d -o lib/direct/libdirect-2.0.so.0.0.0.p/os_linux_system.c.o -c ../../lib/direct/os/linux/system.c
../../lib/direct/os/linux/system.c: In function ‘direct_futex’:
../../lib/direct/os/linux/system.c:153:19: error: ‘__NR_futex’ undeclared (first use in this function)
  153 |      if (syscall( __NR_futex, uaddr, op, val, timeout, uaddr2, val3 ) < 0)
      |                   ^~~~~~~~~~
../../lib/direct/os/linux/system.c:153:19: note: each undeclared identifier is reported only once for each function it appears in
[36/181] Compiling C object lib/direct/libdirect-2.0.so.0.0.0.p/stream.c.o
ninja: build stopped: subcommand failed.
Assert failed: " meson compile -C build/riscv "
```

Reference:
[1] [glibc for 32-bit kernel without __ARCH_WANT_TIME32_SYSCALLS](https://sourceware.org/legacy-ml/libc-alpha/2019-06/msg00557.html)
[2] [openembedded-core: 0001-fiber-libs-Define-SYS_futex-if-it-does-not-exist.patch](https://git.openembedded.org/openembedded-core/tree/meta/recipes-support/boost/boost/0001-fiber-libs-Define-SYS_futex-if-it-does-not-exist.patch?h=honister)